### PR TITLE
Remove circular dependency on LWP::RobotUA introduced in 6.02 (GH#29)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for HTTP-Daemon
 
 {{$NEXT}}
+  - Remove circular dependency on LWP::RobotUA introduced in 6.02 (GH#29)
+    (Olaf Alders)
 
 6.03      2019-04-01 20:56:38Z
   - Remove circular dependency with LWP::UserAgent introduced in 6.02 (GH#27)

--- a/t/robot/ua-get.t
+++ b/t/robot/ua-get.t
@@ -1,3 +1,5 @@
+use Test::Needs 'LWP::RobotUA';
+
 if($^O eq "MacOS") {
     print "1..0\n";
     exit(0);
@@ -64,7 +66,6 @@ sub url {
 
 print "Will access HTTP server at $base\n";
 
-require LWP::RobotUA;
 require HTTP::Request;
 $ua = new LWP::RobotUA 'lwp-spider/0.1', 'gisle@aas.no';
 $ua->delay(0.05);  # rather quick robot

--- a/t/robot/ua.t
+++ b/t/robot/ua.t
@@ -1,3 +1,5 @@
+use Test::Needs 'LWP::RobotUA';
+
 if($^O eq "MacOS") {
     print "1..0\n";
     exit(0);
@@ -64,7 +66,6 @@ sub url {
 
 print "Will access HTTP server at $base\n";
 
-require LWP::RobotUA;
 require HTTP::Request;
 $ua = new LWP::RobotUA 'lwp-spider/0.1', 'gisle@aas.no';
 $ua->delay(0.05);  # rather quick robot


### PR DESCRIPTION
Fixes #28 