### PR TITLE
Use IO::Socket::IP for IPv6 support.

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,8 @@ Revision history for HTTP-Daemon
   - Tidied Daemon.pm
   - Turned on EOL and tab tests
   - Removed obvious indirect object syntax in test suite
+  - Added IPv6 support. (GH#24) Thanks, @ppisar and @intrigeri
+  - Added IO::Socket::IP as a prerequisite rather than IO::Socket::INET
 
 6.04      2019-04-02 13:09:45Z
   - Remove circular dependency on LWP::RobotUA introduced in 6.02 (GH#29)

--- a/lib/HTTP/Daemon.pm
+++ b/lib/HTTP/Daemon.pm
@@ -55,11 +55,15 @@ sub url {
     else {
         my $host = $self->sockhostname;
         if (!defined $host) {
-            if (sockaddr_family($addr) eq AF_INET6) {
+            my $family = sockaddr_family($self->sockname);
+            if ($family && $family == AF_INET6) {
                 $host = '[' . inet_ntop(AF_INET6, $addr) . ']';
             }
+            elsif ($family && $family == AF_INET) {
+                $host = inet_ntop(AF_INET, $addr);
+            }
             else {
-                $host = inet_ntop(AF_INET6, $addr);
+                die "Unknown family";
             }
         }
         $url .= $host;

--- a/lib/HTTP/Daemon.pm
+++ b/lib/HTTP/Daemon.pm
@@ -53,7 +53,7 @@ sub url {
         $url .= '[' . inet_ntop(AF_INET6, $addr) . ']';
     }
     else {
-        my $host = $addr->sockhostname;
+        my $host = $self->sockhostname;
         if (!defined $host) {
             if (sockaddr_family($addr) eq AF_INET6) {
                 $host = '[' . inet_ntop(AF_INET6, $addr) . ']';

--- a/t/local/http.t
+++ b/t/local/http.t
@@ -12,7 +12,7 @@ unless (-f "CAN_TALK_TO_OURSELF") {
 
 $| = 1;    # autoflush
 
-require IO::Socket;   # make sure this work before we try to make a HTTP::Daemon
+require IO::Socket::IP;   # make sure this work before we try to make a HTTP::Daemon
 
 # First we make ourself a daemon in another process
 my $D = shift || '';

--- a/t/robot/ua-get.t
+++ b/t/robot/ua-get.t
@@ -11,7 +11,7 @@ unless (-f "CAN_TALK_TO_OURSELF") {
 }
 
 $| = 1;               # autoflush
-require IO::Socket;   # make sure this work before we try to make a HTTP::Daemon
+require IO::Socket::IP;   # make sure this work before we try to make a HTTP::Daemon
 
 # First we make ourself a daemon in another process
 my $D = shift || '';

--- a/t/robot/ua.t
+++ b/t/robot/ua.t
@@ -11,7 +11,7 @@ unless (-f "CAN_TALK_TO_OURSELF") {
 }
 
 $| = 1;               # autoflush
-require IO::Socket;   # make sure this work before we try to make a HTTP::Daemon
+require IO::Socket::IP;   # make sure this work before we try to make a HTTP::Daemon
 
 # First we make ourself a daemon in another process
 my $D = shift || '';


### PR DESCRIPTION
@ppisar and @intrigeri provided a patch for Debian and Fedora based
distributions as lined out in issue #24. That patch was implemented here
and has been reviewed by the author of IP::Socket::IP, @leonerd