### PR TITLE
Ipv6 next

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for HTTP-Daemon
 
 {{$NEXT}}
+  - Handle undef and empty LocalAddr value in new() constructor as an
+    unspecified address (GH#24, RT#123069)
 
 6.05      2019-07-26 20:41:05Z
   - Added the .perltidyrc from the libwww-perl distribution

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for HTTP-Daemon
 
 {{$NEXT}}
+  - Delimit IPv6 numeric address with brackets and URI-quote an IPv6 zone
+    separator in url() method output
   - Handle undef and empty LocalAddr value in new() constructor as an
     unspecified address (GH#24, RT#123069)
 

--- a/lib/HTTP/Daemon.pm
+++ b/lib/HTTP/Daemon.pm
@@ -62,6 +62,20 @@ sub url {
     }
     else {
         my $host = $self->sockhostname;
+
+        # sockhostname() seems to return a stringified IP address if not
+        # resolvable. Then quote it for a port separator and an IPv6 zone
+        # separator. But be paranoid for a case when it already contains
+        # a bracket.
+        if (defined $host and $host =~ /:/) {
+            if ($host =~ /[\[\]]/) {
+                $host = undef;
+            }
+            else {
+                $host =~ s/%/%25/g;
+                $host = '[' . $host . ']';
+            }
+        }
         if (!defined $host) {
             my $family = sockaddr_family($self->sockname);
             if ($family && $family == AF_INET6) {

--- a/lib/HTTP/Daemon.pm
+++ b/lib/HTTP/Daemon.pm
@@ -22,6 +22,14 @@ sub new {
     my ($class, %args) = @_;
     $args{Listen} ||= 5;
     $args{Proto}  ||= 'tcp';
+
+    # Handle undefined or empty local address the same way as
+    # IO::Socket::INET -- use unspecified address
+    for my $key (qw(LocalAddr LocalHost)) {
+        if (exists $args{$key} && (!defined $args{$key} || $args{$key} eq '')) {
+            delete $args{$key};
+        }
+    }
     return $class->SUPER::new(%args);
 }
 


### PR DESCRIPTION
These two additional patches improves IPv6 support and compatibility with the previous IPv4-only versions. Since HTTP-Daemon-6.05 support IPv6 now and suffers from the issues fixed by the patches now, it's time for merging them to the upstream.

I developed them for Fedora and RHEL where they have been carried for some time as a reaction for issues discovered in the real world. The patches do not amend tests because they need a specific network and resolver configuration that's platform-specific and out of control of the HTTP-Daemon.