### PR TITLE
Improve documentation readability

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for HTTP-Daemon
 
 {{$NEXT}}
+  - Improve documentation readability (GH#36) (Ferenc Erki)
 
 6.06      2019-08-29 14:23:17Z
   - Delimit IPv6 numeric address with brackets and URI-quote an IPv6 zone
@@ -34,7 +35,7 @@ Revision history for HTTP-Daemon
 6.01    2012-02-18
   - If you bind localhost, don't trust gethostbyaddr() to resolve the address.
     RT#67247
-  - Restore perl-5.8.1 compatiblity.
+  - Restore perl-5.8.1 compatibility.
 
 6.00    2011-02-25
   - Initial release of HTTP-Daemon as a separate distribution. There are no code

--- a/README.pod
+++ b/README.pod
@@ -19,13 +19,13 @@ version 6.06
   print "Please contact me at: <URL:", $d->url, ">\n";
   while (my $c = $d->accept) {
       while (my $r = $c->get_request) {
-	  if ($r->method eq 'GET' and $r->uri->path eq "/xyzzy") {
+          if ($r->method eq 'GET' and $r->uri->path eq "/xyzzy") {
               # remember, this is *not* recommended practice :-)
-	      $c->send_file_response("/etc/passwd");
-	  }
-	  else {
-	      $c->send_error(RC_FORBIDDEN)
-	  }
+              $c->send_file_response("/etc/passwd");
+          }
+          else {
+              $c->send_error(RC_FORBIDDEN)
+          }
       }
       $c->close;
       undef($c);
@@ -289,7 +289,7 @@ L<IO::Socket::IP>, L<IO::Socket>
 
 =head1 SUPPORT
 
-bugs may be submitted through L<https://github.com/libwww-perl/HTTP-Daemon/issues>.
+Bugs may be submitted through L<https://github.com/libwww-perl/HTTP-Daemon/issues>.
 
 There is also a mailing list available for users of this distribution, at
 L<mailto:libwww@perl.org>.

--- a/lib/HTTP/Daemon.pm
+++ b/lib/HTTP/Daemon.pm
@@ -639,13 +639,13 @@ __END__
   print "Please contact me at: <URL:", $d->url, ">\n";
   while (my $c = $d->accept) {
       while (my $r = $c->get_request) {
-	  if ($r->method eq 'GET' and $r->uri->path eq "/xyzzy") {
+      if ($r->method eq 'GET' and $r->uri->path eq "/xyzzy") {
               # remember, this is *not* recommended practice :-)
-	      $c->send_file_response("/etc/passwd");
-	  }
-	  else {
-	      $c->send_error(RC_FORBIDDEN)
-	  }
+          $c->send_file_response("/etc/passwd");
+      }
+      else {
+          $c->send_error(RC_FORBIDDEN)
+      }
       }
       $c->close;
       undef($c);
@@ -693,7 +693,7 @@ HTTP port will be constructed like this:
        );
 
 See L<IO::Socket::IP> for a description of other arguments that can
-be used configure the daemon during construction.
+be used to configure the daemon during construction.
 
 =item $c = $d->accept
 
@@ -701,7 +701,7 @@ be used configure the daemon during construction.
 
 =item ($c, $peer_addr) = $d->accept
 
-This method works the same the one provided by the base class, but it
+This method works the same as the one provided by the base class, but it
 returns an C<HTTP::Daemon::ClientConn> reference by default.  If a
 package name is provided as argument, then the returned object will be
 blessed into the given class.  It is probably a good idea to make that
@@ -712,7 +712,7 @@ and no connection is made within the given time.  The timeout() method
 is described in L<IO::Socket::IP>.
 
 In list context both the client object and the peer address will be
-returned; see the description of the accept method L<IO::Socket> for
+returned; see the description of the accept method of L<IO::Socket> for
 details.
 
 =item $d->url
@@ -731,8 +731,8 @@ replaced with the version number of this module.
 
 =back
 
-The C<HTTP::Daemon::ClientConn> is a C<IO::Socket::IP>
-subclass. Instances of this class are returned by the accept() method
+The C<HTTP::Daemon::ClientConn> is a subclass of C<IO::Socket::IP>.
+Instances of this class are returned by the accept() method
 of C<HTTP::Daemon>.  The following methods are provided:
 
 =over 4
@@ -744,7 +744,7 @@ of C<HTTP::Daemon>.  The following methods are provided:
 This method reads data from the client and turns it into an
 C<HTTP::Request> object which is returned.  It returns C<undef>
 if reading fails.  If it fails, then the C<HTTP::Daemon::ClientConn>
-object ($c) should be discarded, and you should not try call this
+object ($c) should be discarded, and you should not try to call this
 method again on it.  The $c->reason method might give you some
 information about why $c->get_request failed.
 
@@ -802,8 +802,8 @@ body must be generated for these requests.
 =item $c->force_last_request
 
 Make sure that $c->get_request will not try to read more requests off
-this connection.  If you generate a response that is not self
-delimiting, then you should signal this fact by calling this method.
+this connection.  If you generate a response that is not self-delimiting,
+then you should signal this fact by calling this method.
 
 This attribute is turned on automatically if the client announces
 protocol HTTP/1.0 or worse and does not include a "Connection:
@@ -850,16 +850,16 @@ Send one or more header lines.
 
 =item $c->send_response( $res )
 
-Write a C<HTTP::Response> object to the
+Write an C<HTTP::Response> object to the
 client as a response.  We try hard to make sure that the response is
-self delimiting so that the connection can stay persistent for further
+self-delimiting so that the connection can stay persistent for further
 request/response exchanges.
 
 The content attribute of the C<HTTP::Response> object can be a normal
 string or a subroutine reference.  If it is a subroutine, then
 whatever this callback routine returns is written back to the
 client as the response content.  The routine will be called until it
-return an undefined or empty value.  If the client is HTTP/1.1 aware
+returns an undefined or empty value.  If the client is HTTP/1.1 aware
 then we will use chunked transfer encoding for the response.
 
 =item $c->send_redirect( $loc )
@@ -869,7 +869,7 @@ then we will use chunked transfer encoding for the response.
 =item $c->send_redirect( $loc, $code, $entity_body )
 
 Send a redirect response back to the client.  The location ($loc) can
-be an absolute or relative URL. The $code must be one the redirect
+be an absolute or relative URL. The $code must be one of the redirect
 status codes, and defaults to "301 Moved Permanently"
 
 =item $c->send_error
@@ -880,7 +880,7 @@ status codes, and defaults to "301 Moved Permanently"
 
 Send an error response back to the client.  If the $code is missing a
 "Bad Request" error is reported.  The $error_message is a string that
-is incorporated in the body of the HTML entity body.
+is incorporated in the body of the HTML entity.
 
 =item $c->send_file_response( $filename )
 


### PR DESCRIPTION
I was pointed to this repo via [Pull Request Club](https://pullrequest.club/), and while I was reading the docs to orient myself, I've noticed a bunch of possibilities to improve readability, like:
  - fix typos
  - add missing words
  - reorder words
  - remove duplicate words

The length of the lines should still be under 80 characters, but I can reformat the patch to keep them even shorter if needed.

There are some others left out of this PR, like highlighting more inline code bits to help with line break rendering, or to use consistent amount of spaces between sentences. So I'm happy to add more to this PR, and also to split this combined commit into smaller ones if needed.

p.s.: English is not my native language, so please proofread the changes carefully, and let me know if you'd like to me update anything.