### PR TITLE
prefer ip address for host in $d->url

### DIFF
--- a/t/url.t
+++ b/t/url.t
@@ -1,0 +1,62 @@
+use strict;
+use warnings;
+
+use Test::More 0.98;
+
+use Config;
+use HTTP::Daemon;
+use HTTP::Response;
+use HTTP::Tiny;
+
+my $can_fork
+    = $Config{d_fork}
+    || (($^O eq 'MSWin32' || $^O eq 'NetWare')
+    and $Config{useithreads}
+    and $Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
+
+plan skip_all => "This system cannot fork" if !$can_fork;
+
+my $d = HTTP::Daemon->new or die "HTTP::Daemon->new: $!";
+
+my $url = $d->url;
+note "url: $url";
+
+my $pid = fork;
+die "fork: $!" if !defined $pid;
+
+if ($pid == 0) {
+    my $http = HTTP::Tiny->new(
+        timeout => 3,
+        proxy => undef,
+        http_proxy => undef,
+        https_proxy => undef,
+    );
+    my $res;
+    eval {
+        local $SIG{ALRM} = sub { die "alarm\n" };
+        alarm 4;
+        $res = $http->get($url);
+    };
+    my $err = $@;
+    alarm 0;
+    exit if $res && $res->{success};
+    if ($err) {
+        diag $err;
+    }
+    if ($res) {
+        diag "$res->{status} $res->{reason}";
+        diag $res->{content} if $res->{status} == 599;
+    }
+    exit 1;
+}
+
+my $c = $d->accept or die "accept: $!";
+my $req = $c->get_request;
+$c->send_response(HTTP::Response->new(200));
+$c->close;
+$d->close;
+
+wait;
+is $?, 0;
+
+done_testing;


### PR DESCRIPTION
This PR will fix #38, that is "Sometimes cannot be accessed via $d->url".

# When we are not able to access servers via $d->url

Let's say we create an HTTP::Daemon server by
```
my $d = HTTP::Daemon->new()
```

Then, `$d->sockaddr` is INADDR_ANY (0.0.0.0) or IN6ADDR_ANY (::1),
so `$d->url` returns `http://hostname:XXX/`, where `hostname` is the hostname of the local machine returned by `Sys::Hostname::hostname`, and `XXX` is some port number. 

Then, there are 2 cases that we are not able to access the server via `$d->url`:

* case1: The `hostname` is not resolvable to IP addresses.
  * This can be seen in [OpenBSD result by jkeenan](https://gist.github.com/jkeenan/db062e9bb4967221977fed506ed96506)
* case2: The `hostname` is resolved to IPv4, but $d restricts connections to IPv6 only.
  * At least, on OpenBSD,  IPv6 sockets are always IPv6-only. See [manpage](https://man.openbsd.org/ip6#IPV6_V6ONLY).
  * This can be seen in [FreeBSD result by jkeenan](https://gist.github.com/jkeenan/db062e9bb4967221977fed506ed96506)

# How to fix it

* if `$d->sockhost` is '0.0.0.0', then use '127.0.0.1' for host in `$d->url`
* if `$d->sockhost` is '::', then use '::1' for host in `$d->url`
* and in any cases, use ip address (that is `$d->sockhost`), not hostname or domain.

# Backward compatibility

Although this PR will fix #38, we should note that this PR may break some use cases.

As I mentioned above, currently, when we create HTTP::Daemon by `my $d = HTTP::Daemon->new`, `$d->url` becomes `http://hostname:XXX`. 
But after this PR, `$d->url` will become `http://127.0.0.1:XXX` or `http://[::1]:XXX`.

Apparently, the ip addresses `127.0.0.1` and `::1` are reasonable only in the local machine.
On the other hand, the `hostname` may be reasonable not only in local machine, but also in remote machines.

So this PR may cause an issue "we are not able to access servers from remote machines via `$d->url`".
