### PR TITLE
use HTTP::Tiny 0.042+ for IPv6 support

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for HTTP-Daemon
 
 {{$NEXT}}
+  - Use HTTP::Tiny 0.042+ for IPv6 support (GH#41) (Shoichi Kaji)
 
 6.07      2020-05-19 19:19:53Z (TRIAL RELEASE)
   - Prefer IP address for host in $d->url (GH#40) (Shoichi Kaji)

--- a/t/url.t
+++ b/t/url.t
@@ -6,7 +6,7 @@ use Test::More 0.98;
 use Config;
 use HTTP::Daemon;
 use HTTP::Response;
-use HTTP::Tiny;
+use HTTP::Tiny 0.042;
 
 my $can_fork
     = $Config{d_fork}


### PR DESCRIPTION
For IPv6, we should have used HTTP::Tiny 0.042+.
See https://metacpan.org/source/DAGOLDEN/HTTP-Tiny-0.076/Changes#L259