### PR TITLE
leave choosing IP address family to IO::Socket::IP

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for HTTP-Daemon
 
 {{$NEXT}}
+  - In t/chunked.t, leave choosing IP address family to IO::Socket::IP (GH#42) (Shoichi Kaji)
 
 6.07      2020-05-19 19:19:53Z (TRIAL RELEASE)
   - Prefer IP address for host in $d->url (GH#40) (Shoichi Kaji)


### PR DESCRIPTION
Close #39 

Currently, in `t/chunked.t`, we choose IP  address family by ourselves.

However, on TravisCI bionic ubuntu,
while we are able to listen `::`, we are not able to connect the server via `::1`.
Therefore `t/chunked.t` fails.
I confirmed this by
* https://github.com/skaji/travis-test2/blob/5cd8eb2b/test.pl
* https://travis-ci.com/github/skaji/travis-test2/builds/167605307
    ```
    # Bionic
    ---> Case: set LocalAddr => :: for IO::Socket::IP
    Successfully created a TCP server on :::8445
    Failed to connect the server via ::1:8445, Network is unreachable
    ```

On the other hand, if we leave choosing IP address family to IO::Socket::IP,
then it detects IPv4 address in TravisCI bionic ubuntu, and we are able to connect servers via `127.0.0.1`.

So let us leave choosing IP address family to IO::Socket::IP.