### PR TITLE
require IO::Socket::IP 0.25 so that HTTP::Tiny uses it

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for HTTP-Daemon
 
 {{$NEXT}}
+  - Require IO::Socket::IP 0.25 so that HTTP::Tiny uses it (GH#45) (Shoichi Kaji)
 
 6.08      2020-05-22 15:26:00Z (TRIAL RELEASE)
   - In t/chunked.t, leave choosing IP address family to IO::Socket::IP (GH#42) (Shoichi Kaji)

--- a/t/url.t
+++ b/t/url.t
@@ -7,6 +7,7 @@ use Config;
 use HTTP::Daemon;
 use HTTP::Response;
 use HTTP::Tiny 0.042;
+use IO::Socket::IP 0.25;
 
 my $can_fork
     = $Config{d_fork}


### PR DESCRIPTION
See https://metacpan.org/source/DAGOLDEN/HTTP-Tiny-0.076/lib/HTTP/Tiny.pm#L1017

This will fix http://www.cpantesters.org/cpan/report/31cf3ed8-9c6e-11ea-aa83-99281f24ea8f