### PR TITLE
An IPv6 zone separator must be URI-quoted

### DIFF
--- a/lib/HTTP/Daemon.pm
+++ b/lib/HTTP/Daemon.pm
@@ -47,6 +47,7 @@ sub url {
     my $self = shift;
 
     my $host = $self->sockhost;
+    $host =~ s/%/%25/g;
     $host = "127.0.0.1" if $host eq "0.0.0.0";
     $host = "::1"       if $host eq "::";
     $host = "[$host]"   if $self->sockdomain == Socket::AF_INET6;


### PR DESCRIPTION
This is wrong:

$ perl -Ilib -e 'use HTTP::Daemon; $d=HTTP::Daemon->new(LocalAddr=>q{fe80::250:54ff:fe00:f01%ens3}) or die; print $d->url(), qq{\n}'
http://[fe80::250:54ff:fe00:f01%ens3]:50263/

The per-cent character must be quoted in an URI. This was fixed in
a 81bd91d29736061e6e9a0d78022e6ea9b6a72e70 commit, but broken later in
6.10 release.