### PR TITLE
An IPv6 zone separator must be URI-quoted

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for HTTP-Daemon
 
 {{$NEXT}}
+  - An IPv6 zone separator must be URI-quoted (GH#47) (Petr Pisar and Olaf
+    Alders)
 
 6.10      2020-05-26 16:20:36Z
   - No changes since TRIAL release 6.09

--- a/lib/HTTP/Daemon.pm
+++ b/lib/HTTP/Daemon.pm
@@ -47,6 +47,7 @@ sub url {
     my $self = shift;
 
     my $host = $self->sockhost;
+    $host =~ s/%/%25/g;
     $host = "127.0.0.1" if $host eq "0.0.0.0";
     $host = "::1"       if $host eq "::";
     $host = "[$host]"   if $self->sockdomain == Socket::AF_INET6;

--- a/t/encoding.t
+++ b/t/encoding.t
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use HTTP::Daemon ();
+use Socket qw( AF_INET6 );
+
+{
+    no warnings 'redefine';
+    local *IO::Socket::sockdomain = sub { return Socket::AF_INET6 };
+    local *IO::Socket::IP::sockhost
+        = sub { return q{fe80::250:54ff:fe00:f01%ens3} };
+
+    my $d = HTTP::Daemon->new;
+    is($d->sockhost, q{fe80::250:54ff:fe00:f01%ens3}, 'we overrode sockhost');
+    is($d->sockdomain, Socket::AF_INET6, 'we overrode sockdomain');
+
+    like(
+        $d->url,
+        qr{\Q[fe80::250:54ff:fe00:f01%25ens3]\E},
+        '% is encoded in host'
+    );
+
+}
+
+done_testing;


### PR DESCRIPTION
Adds a test and a `Changes` entry for #46. Closes #46.