### PR TITLE
Bump minimum IO::Socket::IP version to 0.32

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,6 +10,7 @@ on:
       - "*"
   schedule:
     - cron: "15 4 * * 0" # Every Sunday morning
+  workflow_dispatch:
 
 jobs:
   build:
@@ -18,7 +19,7 @@ jobs:
     strategy:
       max-parallel: 1
     container:
-      image: perldocker/perl-tester:5.30
+      image: perldocker/perl-tester:5.34
     steps:
       - uses: actions/checkout@v2
       - name: Install author deps
@@ -30,7 +31,7 @@ jobs:
       - name: Maybe skip Changes test
         if: github.ref == 'refs/heads/master'
         run: rm dzil_build_dir/xt/release/changes_has_content.t && perl -pi -e "s|'xt/release/changes_has_content.t'||g" dzil_build_dir/xt/author/*
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v2
         with:
           name: build_dir
           path: dzil_build_dir
@@ -76,13 +77,15 @@ jobs:
           - "5.26"
           - "5.28"
           - "5.30"
+          - "5.32"
+          - "5.34"
     container:
       image: perldocker/perl-tester:${{ matrix.perl-version }}
       env:
-        AUTHOR_TESTING: 1
-        RELEASE_TESTING: 1
+        AUTHOR_TESTING: 0
+        RELEASE_TESTING: 0
     steps:
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v2
         with:
           name: build_dir
           path: .
@@ -91,12 +94,11 @@ jobs:
         run: >
           cpm install -g
           --cpanfile cpanfile
-          --with-develop
           --with-suggests
           --show-build-log-on-failure
       - name: Run Tests
         if: success()
-        run: prove -lr --jobs 2 t xt
+        run: prove -lr --jobs 2 t
   test_macos:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -115,29 +117,30 @@ jobs:
           - "5.26"
           - "5.28"
           - "5.30"
+          - "5.34"
     name: Perl ${{ matrix.perl-version }} on ${{ matrix.os }}
     needs: build
     steps:
       - uses: actions/checkout@v2
       - name: Set Up Perl
-        uses: shogo82148/actions-setup-perl@v1.3.0
+        uses: shogo82148/actions-setup-perl@v1
         with:
           perl-version: ${{ matrix.perl-version }}
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v2
         with:
           name: build_dir
           path: .
       - run: perl -V
-      - name: install deps using cpanm
-        uses: perl-actions/install-with-cpm@v1.3
+      - name: install deps using cpm
+        uses: perl-actions/install-with-cpm@v1.4
         with:
           cpanfile: "cpanfile"
           args: "--with-recommends --with-suggests --with-test"
           sudo: false
-      - run: prove -l t xt
+      - run: prove -l t
         env:
-          AUTHOR_TESTING: 1
-          RELEASE_TESTING: 1
+          AUTHOR_TESTING: 0
+          RELEASE_TESTING: 0
   test_windows:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -162,20 +165,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set Up Perl
-        uses: shogo82148/actions-setup-perl@v1.3.0
+        uses: shogo82148/actions-setup-perl@v1
         with:
           perl-version: ${{ matrix.perl-version }}
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v2
         with:
           name: build_dir
           path: .
       - name: install deps using cpanm
-        uses: perl-actions/install-with-cpanm@v1.1
+        uses: perl-actions/install-with-cpm@v1.4
         with:
           cpanfile: "cpanfile"
           sudo: false
       - run: perl -V
-      - run: prove -l t xt
+      - run: prove -l t
         env:
-          AUTHOR_TESTING: 1
-          RELEASE_TESTING: 1
+          AUTHOR_TESTING: 0
+          RELEASE_TESTING: 0

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for HTTP-Daemon
 
 {{$NEXT}}
+  - Bump minimum IO::Socket::IP version to 0.32 (GH#50) (Olaf Alders)
 
 6.12      2020-06-04 16:01:31Z
   - No changes since TRIAL release 6.11

--- a/dist.ini
+++ b/dist.ini
@@ -29,6 +29,7 @@ HTTP::Request = 6
 HTTP::Response = 6
 HTTP::Status = 6
 HTTP::Date = 6
+IO::Socket::IP = 0.32
 LWP::MediaTypes = 6
 
 [Prereqs/DevelopRequires]


### PR DESCRIPTION
Fixes #49

The following error is fixed:

$ .../perl-5.20.2/bin/perl -Mblib t/url.t
url: http://[::1]:13381/
599 Internal Exception
Could not connect to '[::1]:13381': IO::Socket::INET: Bad hostname '[::1]'

As explained by @DrHyde: "IO::Socket::IP only went into core in 5.19.8,
and 0.32 was in 5.21.4, so aside from dev releases, only 5.20.x are
affected by this."
