### PR TITLE
Fix tests

### DIFF
--- a/t/content_length.t
+++ b/t/content_length.t
@@ -248,6 +248,7 @@ sub patch_http_tiny {
     # have been commented out
 
     no strict 'refs';
+    no warnings;
 
     *HTTP::Tiny::Handle::write_content_body = sub {
         @_ == 2 || die(q/Usage: $handle->write_content_body(request)/ . "\n");

--- a/t/content_length.t
+++ b/t/content_length.t
@@ -55,8 +55,9 @@ sub get_tests{
     {
         title   => "Positive Content Length",
         method  => "POST",
+        body    => "ABCDEFGH",
         headers => {
-            'Content-Length' => '+1', # quotes are needed to retain plus-sign
+            'Content-Length' => '+6', # quotes are needed to retain plus-sign
         },
         status  => 400,
         like    => qr/value must be an unsigned integer/,
@@ -64,8 +65,9 @@ sub get_tests{
     {
         title   => "Negative Content Length",
         method  => "POST",
+        body    => "ABCDEFGH",
         headers => {
-            'Content-Length' => '-1',
+            'Content-Length' => '-5',
         },
         status  => 400,
         like    => qr/value must be an unsigned integer/,
@@ -73,6 +75,7 @@ sub get_tests{
     {
         title   => "Non Integer Content Length",
         method  => "POST",
+        body    => "ABCDEFGH",
         headers => {
             'Content-Length' => '3.14',
         },

--- a/t/content_length.t
+++ b/t/content_length.t
@@ -59,7 +59,7 @@ sub get_tests{
             'Content-Length' => '+1', # quotes are needed to retain plus-sign
         },
         status  => 400,
-        like    => qr/value must be a unsigned integer/,
+        like    => qr/value must be an unsigned integer/,
     },
     {
         title   => "Negative Content Length",
@@ -68,7 +68,7 @@ sub get_tests{
             'Content-Length' => '-1',
         },
         status  => 400,
-        like    => qr/value must be a unsigned integer/,
+        like    => qr/value must be an unsigned integer/,
     },
     {
         title   => "Non Integer Content Length",
@@ -77,7 +77,7 @@ sub get_tests{
             'Content-Length' => '3.14',
         },
         status  => 400,
-        like    => qr/value must be a unsigned integer/,
+        like    => qr/value must be an unsigned integer/,
     },
     {
         title   => "Explicit Content Length ... with exact length",


### PR DESCRIPTION
This does fix some of the tests, but sadly not the weird fact that GitLab returns a 200 status, where it should return a 400

- Remove warning
- Fix tests caused by a typo fix earlier

