### PR TITLE
Add content length tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
     container:
       image: perldocker/perl-tester:5.34
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run Tests
         env:
           AUTHOR_TESTING: 1
@@ -28,7 +28,7 @@ jobs:
           RELEASE_TESTING: 1
           TEST_TIDYALL_VERBOSE: 1
         run: auto-build-and-test-dist
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: build_dir
           path: build_dir
@@ -38,8 +38,8 @@ jobs:
     container:
       image: perldocker/perl-tester:5.34
     steps:
-      - uses: actions/checkout@v2 # codecov wants to be inside a Git repository
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3 # codecov wants to be inside a Git repository
+      - uses: actions/download-artifact@v3
         with:
           name: build_dir
           path: .
@@ -74,7 +74,7 @@ jobs:
         AUTHOR_TESTING: 0
         RELEASE_TESTING: 0
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: build_dir
           path: .
@@ -110,12 +110,12 @@ jobs:
     name: Perl ${{ matrix.perl-version }} on ${{ matrix.os }}
     needs: build
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set Up Perl
         uses: shogo82148/actions-setup-perl@v1
         with:
           perl-version: ${{ matrix.perl-version }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: build_dir
           path: .
@@ -152,12 +152,12 @@ jobs:
     name: Perl ${{ matrix.perl-version }} on ${{ matrix.os }}
     needs: build
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set Up Perl
         uses: shogo82148/actions-setup-perl@v1
         with:
           perl-version: ${{ matrix.perl-version }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: build_dir
           path: .

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - "*"
   schedule:
-    - cron: "15 4 * * 0" # Every Sunday morning
+    - cron: "15 4 * * 0"  # Every Sunday morning
   workflow_dispatch:
 
 jobs:
@@ -38,7 +38,7 @@ jobs:
     container:
       image: perldocker/perl-tester:5.36
     steps:
-      - uses: actions/checkout@v3 # codecov wants to be inside a Git repository
+      - uses: actions/checkout@v3  # codecov wants to be inside a Git repository
       - uses: actions/download-artifact@v3
         with:
           name: build_dir
@@ -140,13 +140,13 @@ jobs:
         os: ["windows-latest"]
         perl-version:
           # https://github.com/shogo82148/actions-setup-perl/issues/223
-          #- "5.10"
-          #- "5.12"
-          #- "5.14"
-          #- "5.16"
-          #- "5.18"
-          #- "5.20"
-          #- "5.22"
+          # - "5.10"
+          # - "5.12"
+          # - "5.14"
+          # - "5.16"
+          # - "5.18"
+          # - "5.20"
+          # - "5.22"
           - "5.24"
           - "5.26"
           - "5.28"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-20.04
     container:
-      image: perldocker/perl-tester:5.34
+      image: perldocker/perl-tester:5.36
     steps:
       - uses: actions/checkout@v3
       - name: Run Tests
@@ -36,7 +36,7 @@ jobs:
     needs: build
     runs-on: ubuntu-20.04
     container:
-      image: perldocker/perl-tester:5.34
+      image: perldocker/perl-tester:5.36
     steps:
       - uses: actions/checkout@v3 # codecov wants to be inside a Git repository
       - uses: actions/download-artifact@v3
@@ -68,6 +68,7 @@ jobs:
           - "5.30"
           - "5.32"
           - "5.34"
+          - "5.36"
     container:
       image: perldocker/perl-tester:${{ matrix.perl-version }}
       env:
@@ -107,6 +108,7 @@ jobs:
           - "5.28"
           - "5.30"
           - "5.34"
+          - "5.36"
     name: Perl ${{ matrix.perl-version }} on ${{ matrix.os }}
     needs: build
     steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -92,7 +92,7 @@ jobs:
   test_macos:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: ["macos-latest"]
         perl-version:
@@ -135,7 +135,7 @@ jobs:
   test_windows:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: ["windows-latest"]
         perl-version:

--- a/Changes
+++ b/Changes
@@ -6,6 +6,7 @@ Revision history for HTTP-Daemon
     (Theo van Hoesel)
     Closes "Discrepancies in the Parsing of Content Length header ..." (GH#56)
     (blessingcharles)
+  - Add content length tests (GH#60) (Theo van Hoesel and Olaf Alders)
 
 6.14      2022-03-03 20:47:51Z
   - Test using loopback rather than internet accessible address (GH#52)

--- a/t/content_length.t
+++ b/t/content_length.t
@@ -55,29 +55,32 @@ sub get_tests{
     {
         title   => "Positive Content Length",
         method  => "POST",
+        body    => "ABCDEFGH",
         headers => {
-            'Content-Length' => '+1', # quotes are needed to retain plus-sign
+            'Content-Length' => '+6', # quotes are needed to retain plus-sign
         },
         status  => 400,
-        like    => qr/value must be a unsigned integer/,
+        like    => qr/value must be an unsigned integer/,
     },
     {
         title   => "Negative Content Length",
         method  => "POST",
+        body    => "ABCDEFGH",
         headers => {
-            'Content-Length' => '-1',
+            'Content-Length' => '-5',
         },
         status  => 400,
-        like    => qr/value must be a unsigned integer/,
+        like    => qr/value must be an unsigned integer/,
     },
     {
         title   => "Non Integer Content Length",
         method  => "POST",
+        body    => "ABCDEFGH",
         headers => {
             'Content-Length' => '3.14',
         },
         status  => 400,
-        like    => qr/value must be a unsigned integer/,
+        like    => qr/value must be an unsigned integer/,
     },
     {
         title   => "Explicit Content Length ... with exact length",
@@ -248,6 +251,7 @@ sub patch_http_tiny {
     # have been commented out
 
     no strict 'refs';
+    no warnings;
 
     *HTTP::Tiny::Handle::write_content_body = sub {
         @_ == 2 || die(q/Usage: $handle->write_content_body(request)/ . "\n");

--- a/t/content_length.t
+++ b/t/content_length.t
@@ -1,14 +1,14 @@
+#!perl
+
 use strict;
 use warnings;
 
+use Config qw( %Config );
+use HTTP::Daemon ();
+use HTTP::Response ();
+use HTTP::Status qw( RC_NOT_FOUND );
+use HTTP::Tiny 0.042 ();
 use Test::More 0.98;
-
-use Config;
-
-use HTTP::Daemon;
-use HTTP::Response;
-use HTTP::Status;
-use HTTP::Tiny 0.042;
 
 patch_http_tiny(); # do not fix Content-Length, we want to forge something bad
 

--- a/t/content_length.t
+++ b/t/content_length.t
@@ -12,7 +12,8 @@ use Test::More 0.98;
 
 patch_http_tiny(); # do not fix Content-Length, we want to forge something bad
 
-plan skip_all => "This system cannot fork" unless can_fork();
+plan skip_all => 'This system cannot fork' unless can_fork();
+plan skip_all => 'Tests break under Windows' if $^O eq 'MSWin32';
 
 my $BASE_URL;
 my @TESTS = get_tests();


### PR DESCRIPTION
- Fix tests to match with correct grammar in error message
- Remove warnings about Subroutine write_content_body redefined
- Send some body to see what we get returned
- Tidy imports in t/content_length.t
- Skip t/content_length.t under Windows

Closes #58
Closes #59 