### PR TITLE
create TestServer test lib for running daemon process

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -79,7 +79,7 @@ jobs:
         uses: perl-actions/install-with-cpm@v1.4
         with:
           cpanfile: "cpanfile"
-          args: "--with-recommends --with-suggests --with-test --with-develop"
+          args: "--with-recommends --with-suggests --with-test"
           sudo: false
       - name: Run Tests
         if: success()
@@ -120,7 +120,7 @@ jobs:
         uses: perl-actions/install-with-cpm@v1.4
         with:
           cpanfile: "cpanfile"
-          args: "--with-recommends --with-suggests --with-test --with-develop"
+          args: "--with-recommends --with-suggests --with-test"
           sudo: false
       - run: prove -lrv t
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,3 @@
-/.ackrc
 /.build/
-!/.gitignore
-/.latest
 /HTTP-Daemon-*/
 /HTTP-Daemon-*.tar.gz
-SSL
-t/CAN_TALK_TO_OURSELF
-t/live/ENABLED
-xx*

--- a/dist.ini
+++ b/dist.ini
@@ -16,9 +16,6 @@ Test::MinimumVersion.max_target_perl = 5.008001
 
 [CPANFile]
 
-[Encoding]
-encoding = latin-1
-filename = t/local/http.t
 
 [MetaResources]
 x_IRC = irc://irc.perl.org/#lwp

--- a/dist.ini
+++ b/dist.ini
@@ -14,6 +14,8 @@ StaticInstall.mode = on
 -remove = Test::PodSpelling     ; TODO
 -remove = pluginbundle version
 -remove = @Git::VersionManager
+-remove = .ackrc
+-remove = .latest
 
 [@Git::VersionManager]
 -remove = Prereqs

--- a/dist.ini
+++ b/dist.ini
@@ -9,6 +9,7 @@ copyright_year = 1995
 authority = cpan:GAAS
 bugtracker = github
 Test::MinimumVersion.max_target_perl = 5.008001
+StaticInstall.mode = on
 -remove = Test::CleanNamespaces ; TODO
 -remove = Test::PodSpelling     ; TODO
 

--- a/dist.ini
+++ b/dist.ini
@@ -34,5 +34,5 @@ HTTP::Date = 6
 IO::Socket::IP = 0.32
 LWP::MediaTypes = 6
 
-[Prereqs / DevelopRequires]
+[Prereqs / TestSuggests]
 LWP::UserAgent = 6.07

--- a/dist.ini
+++ b/dist.ini
@@ -12,9 +12,13 @@ Test::MinimumVersion.max_target_perl = 5.008001
 StaticInstall.mode = on
 -remove = Test::CleanNamespaces ; TODO
 -remove = Test::PodSpelling     ; TODO
+-remove = pluginbundle version
+-remove = @Git::VersionManager
+
+[@Git::VersionManager]
+-remove = Prereqs
 
 [CPANFile]
-
 
 [MetaResources]
 x_IRC = irc://irc.perl.org/#lwp
@@ -28,5 +32,5 @@ HTTP::Date = 6
 IO::Socket::IP = 0.32
 LWP::MediaTypes = 6
 
-[Prereqs/DevelopRequires]
+[Prereqs / DevelopRequires]
 LWP::UserAgent = 6.07

--- a/dist.ini
+++ b/dist.ini
@@ -9,8 +9,6 @@ copyright_year = 1995
 authority = cpan:GAAS
 bugtracker = github
 Test::MinimumVersion.max_target_perl = 5.008001
-; -remove = Test::EOL             ; TODO
-; -remove = Test::NoTabs          ; TODO
 -remove = Test::CleanNamespaces ; TODO
 -remove = Test::PodSpelling     ; TODO
 

--- a/dist.ini
+++ b/dist.ini
@@ -33,4 +33,4 @@ IO::Socket::IP = 0.32
 LWP::MediaTypes = 6
 
 [Prereqs/DevelopRequires]
-LWP::Protocol::https = 6.07
+LWP::UserAgent = 6.07

--- a/t/basic.t
+++ b/t/basic.t
@@ -95,10 +95,10 @@ note "Send file...\n";
 {
     my ($fh, $filename) = tempfile( 'http-daemon-test-XXXXXX', TMPDIR => 1, SUFFIX => '.html' );
     binmode $fh;
-    print $fh <<EOT;
-<html><title>En pr�ve</title>
+    print $fh <<"EOT";
+<html><title>En pr\xF8ve</title>
 <h1>Dette er en testfil</h1>
-Jeg vet ikke hvor stor fila beh�ver � v�re heller, men dette
+Jeg vet ikke hvor stor fila beh\xF8ver \xE5 v\xE6re heller, men dette
 er sikkert nok i massevis.
 EOT
     close $fh;
@@ -110,9 +110,9 @@ EOT
 
     ok($res->is_success);
     is($res->content_type,   'text/html');
-    is($res->content_length, 155);
-    is($res->title,          'En pr�ve');
-    like($res->content,      qr/� v�re/);
+    is($res->content_length, 147);
+    is($res->title,          "En pr\xF8ve");
+    like($res->content,      qr/\xE5 v\xE6re/);
 
     unlink $filename;
 

--- a/t/content_length.t
+++ b/t/content_length.t
@@ -3,276 +3,142 @@ use warnings;
 
 use Test::More 0.98;
 
-use Config;
-
-use HTTP::Daemon;
+use HTTP::Request; 
 use HTTP::Response;
-use HTTP::Status;
-use HTTP::Tiny 0.042;
+use IO::Socket::IP;
+use lib 't/lib';
+use TestServer::Reflect;
+use Socket qw($CRLF);
+use IO::Select;
 
-patch_http_tiny(); # do not fix Content-Length, we want to forge something bad
-
-plan skip_all => "This system cannot fork" unless can_fork();
-
-my $BASE_URL;
-my @TESTS = get_tests();
-
-for my $test (@TESTS) {
-
-    my $http_daemon = HTTP::Daemon->new() or die "HTTP::Daemon->new: $!";
-    $BASE_URL = $http_daemon->url;
-
-    my $pid = fork;
-    die "fork: $!" if !defined $pid;
-    if ($pid == 0) {
-        accept_requests($http_daemon);
-    }
-
-    my $resp = http_test_request($test);
-
-    ok $resp, $test->{title};
-
-    is $resp->{status}, $test->{status},
-        "... and has expected status";
-
-    like $resp->{content}, $test->{like},
-        "... and body does match"
-        if $test->{like};
-
-}
-
-done_testing;
-
-
-
-sub get_tests{
-    {
-        title   => "Hello World Request ... it works as expected",
-        path    => "hello-world",
-        status  => 200,
-        like    => qr/^Hello World$/,
-    },
+my @TESTS = (
     {
         title   => "Positive Content Length",
-        method  => "POST",
-        headers => {
-            'Content-Length' => '+1', # quotes are needed to retain plus-sign
-        },
+        raw => <<'END_RAW',
+POST /echo HTTP/1.1
+Content-Length: +1
+
+END_RAW
+
         status  => 400,
-        like    => qr/value must be a unsigned integer/,
+        like    => qr/value must be an unsigned integer/,
     },
     {
         title   => "Negative Content Length",
-        method  => "POST",
-        headers => {
-            'Content-Length' => '-1',
-        },
+        raw     => <<'END_RAW',
+POST /echo HTTP/1.1
+Content-Length: -1
+
+END_RAW
         status  => 400,
-        like    => qr/value must be a unsigned integer/,
+        like    => qr/value must be an unsigned integer/,
     },
     {
         title   => "Non Integer Content Length",
-        method  => "POST",
-        headers => {
-            'Content-Length' => '3.14',
-        },
+        raw     => <<'END_RAW',
+POST /echo HTTP/1.1
+Content-Length: 3.14
+
+END_RAW
         status  => 400,
-        like    => qr/value must be a unsigned integer/,
+        like    => qr/value must be an unsigned integer/,
     },
     {
         title   => "Explicit Content Length ... with exact length",
-        method  => "POST",
-        headers => {
-            'Content-Length' => '8',
-        },
-        body    => "ABCDEFGH",
+        raw     => <<'END_RAW',
+POST /echo HTTP/1.1
+Content-Length: 8
+
+ABCDEFGH
+END_RAW
         status  => 200,
         like    => qr/^ABCDEFGH$/,
     },
     {
-        title   => "Implicit Content Length ... will always pass",
-        method  => "POST",
-        body    => "ABCDEFGH",
+        title   => "No Content Length with body ... will be ignored",
+        raw     => <<'END_RAW',
+POST /echo HTTP/1.1
+
+ABCDEFGH
+END_RAW
         status  => 200,
-        like    => qr/^ABCDEFGH$/,
+        like    => qr/^$/,
     },
     {
         title   => "Shorter Content Length ... gets truncated",
-        method  => "POST",
-        headers => {
-            'Content-Length' => '4',
-        },
-        body    => "ABCDEFGH",
+        raw     => <<'END_RAW',
+POST /echo HTTP/1.1
+Content-Length: 4
+
+ABCDEFGH
+END_RAW
         status  => 200,
         like    => qr/^ABCD$/,
     },
     {
         title   => "Different Content Length ... must fail",
-        method  => "POST",
-        headers => {
-            'Content-Length' => ['8', '4'],
-        },
-        body    => "ABCDEFGH",
-        status  => 400,
-        like    => qr/values are not the same/,
-    },
-    {
-        title   => "Underscore Content Length ... must match",
-        method  => "POST",
-        headers => {
-            'Content_Length' => '4',
-        },
-        body    => "ABCDEFGH",
+        raw     => <<'END_RAW',
+POST /echo HTTP/1.1
+Content-Length: 8
+Content-Length: 4
+
+ABCDEFGH
+END_RAW
         status  => 400,
         like    => qr/values are not the same/,
     },
     {
         title   => "Longer Content Length ... gets timeout",
-        method  => "POST",
-        headers => {
-            'Content-Length' => '9',
-        },
-        body    => "ABCDEFGH",
-        status  => 599, # silly code !!!
-        like    => qr/^Timeout/,
+        raw     => <<'END_RAW',
+POST /echo HTTP/1.1
+Content-Length: 9
+
+ABCDEFGH
+END_RAW
+        timeout => 1,
     },
+);
 
-}
+my $daemon = TestServer::Reflect->new;
+my $url = $daemon->start;
 
+my $addr = $url->host;
+my $port = $url->port;
 
+for my $test (@TESTS) {
+    my $raw = $test->{raw} or next;
+    $raw =~ s/(?<!\n)\r?\n\z//;
+    $raw =~ s/\r?\n/$CRLF/g;
 
-sub router_table {
-    {
-        '/hello-world' => {
-            'GET' => sub {
-                my $resp = HTTP::Response->new(200);
-                $resp->content('Hello World');
-                return $resp;
-            },
-        },
+    my $sock = IO::Socket::IP->new(
+        PeerAddr => $addr,
+        PeerPort => $port,
+        Timeout  => 2,
+    ) or die;
 
-        '/' => {
-            'POST' => sub {
-                my $rqst = shift;
+    print $sock $raw;
 
-                my $body = $rqst->content();
-
-                my $resp = HTTP::Response->new(200);
-                $resp->content($body);
-
-                return $resp
-            },
-        },
+    my $select = IO::Select->new;
+    $select->add($sock);
+    my @ready = $select->can_read(2);
+    if (!@ready) {
+        ok $test->{timeout}, $test->{title};
+        next;
     }
+
+    my $raw_res = do { local $/; <$sock> };
+    close $sock;
+
+    my $res = HTTP::Response->parse($raw_res);
+
+    ok $raw_res, $test->{title};
+
+    is $res->code, $test->{status},
+        "... and has expected status";
+
+    like $res->content, $test->{like},
+        "... and body does match"
+        if $test->{like};
 }
 
-
-
-sub can_fork {
-    $Config{d_fork} || (($^O eq 'MSWin32' || $^O eq 'NetWare')
-    and $Config{useithreads}
-    and $Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
-}
-
-
-
-# run the mini HTTP dispatcher that can handle various routes / methods
-sub accept_requests{
-    my $http_daemon = shift;
-    while (my $conn = $http_daemon->accept) {
-        while (my $rqst = $conn->get_request) {
-            if (my $resp = dispatch_request($rqst)) {
-                $conn->send_response($resp);
-            }
-        }
-        $conn->close;
-        undef($conn);
-        $http_daemon->close;
-        exit 1;
-    }
-}
-
-
-
-sub dispatch_request{
-    my $rqst = shift
-        or return;
-    my $path = $rqst->uri->path
-        or return;
-    my $meth = $rqst->method
-        or return;
-    my $code =  router_table()->{$path}{$meth}
-        or return HTTP::Response->new(RC_NOT_FOUND);
-    my $resp = $code->($rqst);
-    return $resp;
-}
-
-
-
-sub http_test_request {
-    my $test = shift;
-    my $http_client = HTTP::Tiny->new(
-        timeout => 5,
-        proxy => undef,
-        http_proxy => undef,
-        https_proxy => undef,
-    );
-    my $resp;
-    eval {
-        local $SIG{ALRM} = sub { die "Timeout\n" };
-        alarm 2;
-        $resp = $http_client->request(
-            $test->{method} || "GET",
-            $BASE_URL . ($test->{path} || ""),
-            {
-                headers => $test->{headers},
-                content => $test->{body}
-            },
-        );
-    };
-    my $err = $@;
-    alarm 0;
-    diag $err if $err;
-
-    return $resp
-}
-
-
-
-sub patch_http_tiny {
-
-    # we need to patch write_content_body
-    # this is part of HTTP::Tiny internal module HTTP::Tiny::Handle
-    #
-    # the below code is from the original HTTP::Tiny module, where just two lines
-    # have been commented out
-
-    no strict 'refs';
-
-    *HTTP::Tiny::Handle::write_content_body = sub {
-        @_ == 2 || die(q/Usage: $handle->write_content_body(request)/ . "\n");
-        my ($self, $request) = @_;
-
-        my ($len, $content_length) = (0, $request->{headers}{'content-length'});
-        while () {
-            my $data = $request->{cb}->();
-
-            defined $data && length $data
-                or last;
-
-            if ( $] ge '5.008' ) {
-                utf8::downgrade($data, 1)
-                    or die(qq/Wide character in write_content()\n/);
-            }
-
-            $len += $self->write($data);
-        }
-
-#       this should not be checked during our tests, we want to forge bad requests
-#
-#       $len == $content_length
-#           or die(qq/Content-Length mismatch (got: $len expected: $content_length)\n/);
-
-        return $len;
-    };
-}
+done_testing;

--- a/t/lib/TestServer.pm
+++ b/t/lib/TestServer.pm
@@ -1,0 +1,138 @@
+package TestServer;
+use strict;
+use warnings;
+
+use File::Spec;
+
+sub new {
+    my $class = shift;
+    my $self = bless {}, $class;
+}
+
+sub perl {
+    my ($perl) = $^X =~ /(.*)/;
+    return $perl;
+}
+
+sub lib_dirs {
+    my $self = shift;
+    my $perl = $self->perl;
+    $perl = qq["$perl"]
+      if $perl =~ /\s/;
+
+    my @inc = `$perl -l -e"print for \@INC"`;
+    chomp @inc;
+
+    my %inc = map +($_ => 1), @inc;
+
+    my @libs = grep !$inc{$_}, @INC;
+
+    return @libs;
+}
+
+sub perl_cmd {
+    my $self = shift;
+    my $perl = $self->perl;
+    $perl = qq["$perl"]
+        if $perl =~ /\s/;
+
+    my @libs = $self->lib_dirs;
+    for my $lib ($self->lib_dirs) {
+        my $quoted = $lib =~ /\s/ ? qq["$lib"] : $lib;
+        $perl .= " -I$quoted";
+    }
+
+    return $perl;
+}
+
+sub start {
+    my $self = shift;
+    my $class = ref $self;
+
+    my $perl = $self->perl_cmd;
+
+    my $pid = open my $DAEMON, "$perl -M$class=run -e1 |"
+        or die "Can't exec daemon: $!";
+
+    my $greeting = <$DAEMON>;
+    $greeting =~ /<URL:([^>]+)>/;
+
+    my $base = URI->new("$1");
+
+    $self->{url} = $base;
+    $self->{pid} = $pid;
+    $self->{io} = $DAEMON;
+
+    return $base;
+}
+
+sub stop {
+    my $self = shift;
+    my $pid = delete $self->{pid} or return;
+    my $io = delete $self->{io};
+
+    kill 'QUIT', $pid;
+    close $io;
+
+    waitpid $pid, 0;
+    return;
+}
+
+sub DESTROY {
+    my $self = shift;
+    $self->stop
+        if $self->{pid};
+}
+
+sub url {
+    my $self = shift;
+    my $base = $self->{url};
+    if (@_) {
+        my $u = URI->new(shift);
+        $u = $u->abs($base);
+        if (@_) {
+            my $query = shift;
+            $u->query_form($query);
+        }
+        return $u->as_string;
+    }
+    else {
+        return $base;
+    }
+}
+
+sub import {
+    my $class = shift;
+    if (@_ == 1 && $_[0] eq 'run') {
+        $class->new->run;
+    }
+}
+
+sub run {
+    my $self = shift;
+
+    require HTTP::Daemon;
+    my $d = HTTP::Daemon->new(Timeout => 10);
+
+    print "HTTP::Daemon running at <URL:", $d->url, ">\n";
+    open STDOUT, '>', File::Spec->devnull;
+
+    while (my $c = $d->accept) {
+        my $r = $c->get_request;
+        if ($r) {
+            $self->dispatch($c, $r->method, $r->uri, $r);
+        }
+        $c = undef;    # close connection
+    }
+    print STDERR "HTTP Server terminated\n";
+    exit;
+}
+
+sub dispatch {
+    my $self = shift;
+    my ($c, $method, $uri, $request) = @_;
+
+    $c->send_error(404);
+}
+
+1;

--- a/t/lib/TestServer/BasicTests.pm
+++ b/t/lib/TestServer/BasicTests.pm
@@ -1,0 +1,107 @@
+package TestServer::BasicTests;
+use strict;
+use warnings;
+
+use TestServer ();
+our @ISA = qw(TestServer);
+
+use File::Temp qw(tempfile);
+
+sub dispatch {
+    my $self = shift;
+    my ($c, $method, $uri, $request) = @_;
+    my $p = ($uri->path_segments)[1];
+    my $call = lc("httpd_" . $method . "_$p");
+    if ($self->can($call)) {
+        return $self->$call($c, $request);
+    }
+    $self->SUPER::dispatch(@_);
+}
+
+sub httpd_get_echo {
+    my ($self, $c, $req) = @_;
+    $c->send_basic_header(200);
+    print $c "Content-Type: message/http\015\012";
+    $c->send_crlf;
+    print $c $req->as_string;
+}
+
+sub httpd_get_file {
+    my ($self, $c, $r) = @_;
+    my %form = $r->uri->query_form;
+    my $file = $form{file};
+    $c->send_file_response($file);
+}
+
+sub httpd_get_redirect {
+    my ($self, $c) = @_;
+    $c->send_redirect("/echo/redirect");
+}
+
+sub httpd_get_redirect2 { shift; shift->send_redirect("/redirect3/") }
+sub httpd_get_redirect3 { shift; shift->send_redirect("/redirect2/") }
+
+sub httpd_get_basic {
+    my ($self, $c, $r) = @_;
+
+    #print STDERR $r->as_string;
+    my ($u, $p) = $r->authorization_basic;
+    if (defined($u) && $u eq 'ok 12' && $p eq 'xyzzy') {
+        $c->send_basic_header(200);
+        print $c "Content-Type: text/plain";
+        $c->send_crlf;
+        $c->send_crlf;
+        $c->print("$u\n");
+    }
+    else {
+        $c->send_basic_header(401);
+        $c->print("WWW-Authenticate: Basic realm=\"libwww-perl\"\015\012");
+        $c->send_crlf;
+    }
+}
+
+sub httpd_get_proxy {
+    my ($self, $c, $r) = @_;
+    if ($r->method eq "GET" and $r->uri->scheme eq "ftp") {
+        $c->send_basic_header(200);
+        $c->send_crlf;
+    }
+    else {
+        $c->send_error;
+    }
+}
+
+sub httpd_post_echo {
+    my ($self, $c, $r) = @_;
+    $c->send_basic_header;
+    $c->print("Content-Type: text/plain");
+    $c->send_crlf;
+    $c->send_crlf;
+
+    # Do it the hard way to test the send_file
+    my ($fh, $filename) = tempfile('http-daemon-test-XXXXXX', TMPDIR => 1);
+    binmode $fh;
+    print $fh $r->as_string;
+    close $fh;
+
+    $c->send_file($filename);
+
+    unlink($filename);
+}
+
+sub httpd_get_partial {
+    my ($self, $c) = @_;
+    $c->send_basic_header(206);
+    print $c "Content-Type: image/jpeg\015\012";
+    $c->send_crlf;
+    print $c "some fake JPEG content";
+
+}
+
+sub httpd_get_quit {
+    my ($self, $c) = @_;
+    $c->send_error(503, "Bye, bye");
+    exit;                    # terminate HTTP server
+}
+
+1;

--- a/t/lib/TestServer/Reflect.pm
+++ b/t/lib/TestServer/Reflect.pm
@@ -1,0 +1,32 @@
+package TestServer::Reflect;
+use strict;
+use warnings;
+
+use TestServer ();
+our @ISA = qw(TestServer);
+
+use HTTP::Response;
+
+sub dispatch {
+    my $self = shift;
+    my ($c, $method, $uri, $request) = @_;
+
+    if ($uri eq '/content-length') {
+        my $res = HTTP::Response->new(200);
+        $res->content(length $request->content);
+        $c->send_response($res);
+    }
+    elsif ($uri eq '/echo') {
+        my $res = HTTP::Response->new(200);
+        $res->content($request->content);
+        $c->send_response($res);
+    }
+    else {
+        $c->send_error(404);
+    }
+
+    $c->force_last_request;    # we're just not mature enough
+    $c->close;
+}
+
+1;


### PR DESCRIPTION
Create a TestServer test library that serves as both a subclassable server and a lib for running that server. Having one class for both the internals of the server and the external interface to start it is a bit ugly, but makes extending it and using it a bit easier. And it's only a test library so it seems a reasonable compromise.

This will run the server as a sub process rather than using forking, so it is more portable.

Convert the tests to use this library rather than each having their own routines for running for forking the daemon.