### PR TITLE
kill test server with KILL rather than QUIT

### DIFF
--- a/t/lib/TestServer.pm
+++ b/t/lib/TestServer.pm
@@ -71,7 +71,7 @@ sub stop {
     my $pid = delete $self->{pid} or return;
     my $io = delete $self->{io};
 
-    kill 'QUIT', $pid;
+    kill 'KILL', $pid;
     close $io;
 
     waitpid $pid, 0;


### PR DESCRIPTION
Using QUIT will cause perl on win32 to spew warnings "Terminating on signal SIGQUIT". We don't need the process to shut down gracefully, so we can just kill it using KILL, which avoids these messages.