### PR TITLE
bump github runner version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,8 +8,6 @@ on:
   pull_request:
     branches:
       - "*"
-  schedule:
-    - cron: "15 4 * * 0" # Every Sunday morning
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,18 +24,18 @@ jobs:
         run: >
           cpan-install-build-deps;
           build-dist
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: build_dir
           path: build_dir
   coverage-job:
     needs: build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-2.04
     container:
       image: perldocker/perl-tester:5.34
     steps:
       - uses: actions/checkout@v2 # codecov wants to be inside a Git repository
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: build_dir
           path: .
@@ -70,7 +70,7 @@ jobs:
         AUTHOR_TESTING: 0
         RELEASE_TESTING: 0
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: build_dir
           path: .
@@ -111,7 +111,7 @@ jobs:
         uses: shogo82148/actions-setup-perl@v1
         with:
           perl-version: ${{ matrix.perl-version }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: build_dir
           path: .
@@ -153,7 +153,7 @@ jobs:
         uses: shogo82148/actions-setup-perl@v1
         with:
           perl-version: ${{ matrix.perl-version }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: build_dir
           path: .

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
     name: Build distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container:
       image: perldocker/perl-tester:5.34
     steps:
@@ -30,7 +30,7 @@ jobs:
           path: build_dir
   coverage-job:
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container:
       image: perldocker/perl-tester:5.34
     steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -89,8 +89,6 @@ jobs:
       matrix:
         os: ["macos-latest"]
         perl-version:
-          - "5.10"
-          - "5.12"
           - "5.14"
           - "5.16"
           - "5.18"


### PR DESCRIPTION
We used to have latest here, but Olaf changed it to 20.04 so I bumped it to 24.04 rather than put it back to latest.