### PR TITLE
Fix CI: extend to Perl 5.42, disable fail-fast, pause Windows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,17 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
+    groups:
+      major-updates:
+        patterns:
+          - '*'
+        update-types:
+          - 'major'
+      minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,10 +4,8 @@ name: dzil build and test
 on:
   push:
     branches:
-      - "*"
+      - master
   pull_request:
-    branches:
-      - "*"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -47,6 +47,7 @@ jobs:
     name: Perl ${{ matrix.perl-version }} on ubuntu-latest
     needs: build
     strategy:
+      fail-fast: false
       matrix:
         perl-version:
           - "5.10"
@@ -85,7 +86,7 @@ jobs:
   test_macos:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: ["macos-latest"]
         perl-version:
@@ -125,7 +126,7 @@ jobs:
   test_windows:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: ["windows-latest"]
         perl-version:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-24.04
     container:
-      image: perldocker/perl-tester:5.34
+      image: perldocker/perl-tester:5.42
     steps:
       - uses: actions/checkout@v6
       - name: Build Dist
@@ -30,7 +30,7 @@ jobs:
     needs: build
     runs-on: ubuntu-24.04
     container:
-      image: perldocker/perl-tester:5.34
+      image: perldocker/perl-tester:5.42
     steps:
       - uses: actions/checkout@v6 # codecov wants to be inside a Git repository
       - uses: actions/download-artifact@v7
@@ -63,6 +63,10 @@ jobs:
           - "5.30"
           - "5.32"
           - "5.34"
+          - "5.36"
+          - "5.38"
+          - "5.40"
+          - "5.42"
     container:
       image: perldocker/perl-tester:${{ matrix.perl-version }}
       env:
@@ -100,6 +104,10 @@ jobs:
           - "5.28"
           - "5.30"
           - "5.34"
+          - "5.36"
+          - "5.38"
+          - "5.40"
+          - "5.42"
     name: Perl ${{ matrix.perl-version }} on ${{ matrix.os }}
     needs: build
     steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -132,6 +132,8 @@ jobs:
           AUTHOR_TESTING: 0
           RELEASE_TESTING: 0
   test_windows:
+    # Temporarily disabled - re-enable by removing this `if`.
+    if: false
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build distribution

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -81,11 +81,13 @@ jobs:
           path: .
       - name: Install deps
         if: success()
-        uses: perl-actions/install-with-cpm@v1.9
+        uses: perl-actions/install-with-cpm@v2
         with:
           cpanfile: "cpanfile"
           args: "--with-recommends --with-suggests --with-test"
           sudo: false
+          # App::cpm v0.999.0+ requires Perl 5.24+; pin older Perls to the last compatible release.
+          version: ${{ matrix.perl-version <= '5.22' && '0.998003' || 'main' }}
       - name: Run Tests
         if: success()
         run: prove -lrv t
@@ -124,11 +126,13 @@ jobs:
           path: .
       - run: perl -V
       - name: install deps using cpm
-        uses: perl-actions/install-with-cpm@v1.9
+        uses: perl-actions/install-with-cpm@v2
         with:
           cpanfile: "cpanfile"
           args: "--with-recommends --with-suggests --with-test"
           sudo: false
+          # App::cpm v0.999.0+ requires Perl 5.24+; pin older Perls to the last compatible release.
+          version: ${{ matrix.perl-version <= '5.22' && '0.998003' || 'main' }}
       - run: prove -lrv t
         env:
           AUTHOR_TESTING: 0
@@ -167,10 +171,12 @@ jobs:
           name: build_dir
           path: .
       - name: install deps using cpanm
-        uses: perl-actions/install-with-cpm@v1.9
+        uses: perl-actions/install-with-cpm@v2
         with:
           cpanfile: "cpanfile"
           sudo: false
+          # App::cpm v0.999.0+ requires Perl 5.24+; pin older Perls to the last compatible release.
+          version: ${{ matrix.perl-version <= '5.22' && '0.998003' || 'main' }}
       - run: perl -V
       - run: prove -lrv t
         env:


### PR DESCRIPTION
## Summary
- Disable `fail-fast` on the Linux, macOS, and Windows matrix jobs so a single failing cell doesn't mask the rest of the matrix.
- Extend the Linux and macOS matrices through Perl 5.42 (adds 5.36, 5.38, 5.40, 5.42) and bump the build and coverage jobs to `perldocker/perl-tester:5.42`.
- Temporarily disable the Windows test job with `if: false` — revert by removing the `if` line.
- Tune `.github/dependabot.yml`: group GitHub Actions minor + patch updates (with majors in their own group to keep coordinated action releases atomic) and add a 7-day cooldown.

## Test plan
- [ ] CI completes on the PR with the new Perl versions present in the matrix.
- [ ] `test_linux` and `test_macos` jobs show 5.36 / 5.38 / 5.40 / 5.42 cells running.
- [ ] `test_windows` does not run (skipped via `if: false`).
- [ ] `build` and `coverage-job` run on the 5.42 image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)