### PR TITLE
Clean up TestServer test library

### DIFF
--- a/t/lib/TestServer.pm
+++ b/t/lib/TestServer.pm
@@ -142,7 +142,7 @@ sub run {
     while (my $c = $d->accept) {
         my $r = $c->get_request;
         if ($r) {
-            $self->dispatch($c, $r->method, $r->uri, $r);
+            $self->dispatch($c, $r);
         }
         $c = undef;    # close connection
     }
@@ -152,7 +152,7 @@ sub run {
 
 sub dispatch {
     my $self = shift;
-    my ($c, $method, $uri, $request) = @_;
+    my ($c) = @_;
 
     $c->send_error(404);
 }

--- a/t/lib/TestServer.pm
+++ b/t/lib/TestServer.pm
@@ -36,7 +36,6 @@ sub perl_cmd {
     $perl = qq["$perl"]
         if $perl =~ /\s/;
 
-    my @libs = $self->lib_dirs;
     for my $lib ($self->lib_dirs) {
         my $quoted = $lib =~ /\s/ ? qq["$lib"] : $lib;
         $perl .= " -I$quoted";

--- a/t/lib/TestServer/BasicTests.pm
+++ b/t/lib/TestServer/BasicTests.pm
@@ -9,7 +9,9 @@ use File::Temp qw(tempfile);
 
 sub dispatch {
     my $self = shift;
-    my ($c, $method, $uri, $request) = @_;
+    my ($c, $request) = @_;
+    my $method = $request->method;
+    my $uri    = $request->uri;
     my $p = ($uri->path_segments)[1];
     my $call = lc("httpd_" . $method . "_$p");
     if ($self->can($call)) {

--- a/t/lib/TestServer/Reflect.pm
+++ b/t/lib/TestServer/Reflect.pm
@@ -9,7 +9,8 @@ use HTTP::Response;
 
 sub dispatch {
     my $self = shift;
-    my ($c, $method, $uri, $request) = @_;
+    my ($c, $request) = @_;
+    my $uri = $request->uri;
 
     if ($uri eq '/content-length') {
         my $res = HTTP::Response->new(200);


### PR DESCRIPTION
Two small, independent cleanups to the `t/lib/TestServer*` test library. Both are test-only and behavior-preserving.

## Remove unused var in test lib

`TestServer::perl_cmd` declared `my @libs = $self->lib_dirs;` and never used it — the loop just below calls `$self->lib_dirs` directly.

## Simplify `dispatch()` interface to `($c, $r)`

`dispatch()` was called as `dispatch($c, $r->method, $r->uri, $r)`, but `$method` and `$uri` are plain accessors on the request object `$r`. Pass only `($c, $r)` and let each `dispatch()` implementation derive `method`/`uri` where it needs them. This also drops `$method` from `TestServer::Reflect::dispatch`, which unpacked it but never used it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)